### PR TITLE
Allow Watching on "/" when using chroot

### DIFF
--- a/src/watch.rs
+++ b/src/watch.rs
@@ -132,7 +132,15 @@ impl<W: Watcher> ZkWatch<W> {
     fn cut_chroot(&self, event: &mut WatchedEvent) {
         if let Some(ref chroot) = self.chroot {
             if event.path.is_some() {
-                event.path = Some(event.path.as_ref().unwrap()[chroot.len()..].to_owned());
+                let mut path_without_chroot =
+                    event.path.as_ref().unwrap()[chroot.len()..].to_owned();
+                if path_without_chroot == "" {
+                    // When there's a watch registered to the chroot itself, the above string split
+                    // would return "". However, the `self.watches` HashMap expects the key to be
+                    // "/"
+                    path_without_chroot = "/".to_owned();
+                }
+                event.path = Some(path_without_chroot);
             }
         }
     }


### PR DESCRIPTION
The Watchers are registered in the `watches` HashMap with key being the
path of interest. Once a watch has been registered for the root "/" and
an event has been triggered for it (i.e. `NodeChildrenChanged`), the call
to `cut_chroot` would be issued to identify the watches. However, the
current `cut_chroot` would return "", instead of the expected  key "/" that
has been already registered in the `watches` HashMap

Signed-off-by: Seb Ospina <kraige@gmail.com>