### PR TITLE
Add supporting of TTL of ZNode and Create2 opcode

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,10 @@
+#!/usr/bin/env just --justfile
+
+compile-zk:
+  cd zk-test-cluster && mvn clean package
+
+test: compile-zk
+  cargo test
+
+lint:
+  cargo clippy

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -107,7 +107,9 @@ impl CreateMode {
     pub fn is_sequential(&self) -> bool {
         matches!(
             self,
-            CreateMode::PersistentSequential | CreateMode::EphemeralSequential
+            CreateMode::PersistentSequential
+                | CreateMode::EphemeralSequential
+                | CreateMode::PersistentSequentialWithTTL
         )
     }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -88,11 +88,35 @@ pub enum CreateMode {
     /// the server at some point in the future. Given this property, you should be prepared to get
     /// `ZkError::NoNode` when creating children inside of this container node.
     Container = 4,
+    /// The znode will not be automatically deleted upon client's disconnect, but it will be deleted
+    /// if it has not been modified within the given TTL and has no children.
+    PersistentWithTTL = 5,
+    /// The same as `PersistentSequential`, but the znode will be deleted if it has not been
+    /// modified within the given TTL and has no children.
+    PersistentSequentialWithTTL = 6,
 }
 
 impl From<CreateMode> for String {
     fn from(value: CreateMode) -> Self {
         value.to_string()
+    }
+}
+
+impl CreateMode {
+    /// Returns `true` if the `CreateMode` is one of the sequential types.
+    pub fn is_sequential(&self) -> bool {
+        matches!(
+            self,
+            CreateMode::PersistentSequential | CreateMode::EphemeralSequential
+        )
+    }
+
+    /// Returns `true` if the `CreateMode` is one of the TTL types.
+    pub fn is_ttl(&self) -> bool {
+        matches!(
+            self,
+            CreateMode::PersistentWithTTL | CreateMode::PersistentSequentialWithTTL
+        )
     }
 }
 

--- a/src/zookeeper.rs
+++ b/src/zookeeper.rs
@@ -12,7 +12,13 @@ use tracing::*;
 
 use crate::io::ZkIo;
 use crate::listeners::ListenerSet;
-use crate::proto::{to_len_prefixed_buf, AuthRequest, ByteBuf, CreateRequest, CreateResponse, DeleteRequest, EmptyRequest, EmptyResponse, ExistsRequest, ExistsResponse, GetAclRequest, GetAclResponse, GetChildrenRequest, GetChildrenResponse, GetDataRequest, GetDataResponse, OpCode, ReadFrom, ReplyHeader, RequestHeader, SetAclRequest, SetAclResponse, SetDataRequest, SetDataResponse, WriteTo, CreateTTLRequest, Create2Response};
+use crate::proto::{
+    to_len_prefixed_buf, AuthRequest, ByteBuf, Create2Response, CreateRequest, CreateResponse,
+    CreateTTLRequest, DeleteRequest, EmptyRequest, EmptyResponse, ExistsRequest, ExistsResponse,
+    GetAclRequest, GetAclResponse, GetChildrenRequest, GetChildrenResponse, GetDataRequest,
+    GetDataResponse, OpCode, ReadFrom, ReplyHeader, RequestHeader, SetAclRequest, SetAclResponse,
+    SetDataRequest, SetDataResponse, WriteTo,
+};
 use crate::watch::ZkWatch;
 use crate::{
     Acl, CreateMode, Stat, Subscription, Watch, WatchType, WatchedEvent, Watcher, ZkError, ZkState,
@@ -285,6 +291,8 @@ impl ZooKeeper {
     ///
     /// If the `acl` is invalid or empty, `Err(ZkError::InvalidACL)` is returned.
     ///
+    /// If the `CreateTtl` opcode is not supported by the server, `Err(ZkError::Unimplemented)` is returned.
+    ///
     /// The maximum allowable size of the data array is 1 MiB (1,048,576 bytes). Arrays larger than
     /// this will return `Err(ZkError::BadArguments)`.
     pub async fn create_ttl(
@@ -304,11 +312,38 @@ impl ZooKeeper {
             ttl: ttl.as_millis() as i64,
         };
 
-        let response: CreateResponse = self.request(OpCode::CreateTtl, self.xid(), req, None).await?;
+        let response: CreateResponse = self
+            .request(OpCode::CreateTtl, self.xid(), req, None)
+            .await?;
 
         Ok(self.cut_chroot(response.path))
     }
 
+    /// Create a node with the given `path`. The node data will be the given `data`, and node ACL
+    /// will be the given `acl`. The `mode` argument specifies the behavior of the created node (see
+    /// `CreateMode` for more information).
+    ///
+    /// This operation, if successful, will trigger all the watches left on the node of the given
+    /// path by `exists` and `get_data` API calls, and the watches left on the parent node by
+    /// `get_children` API calls.
+    ///
+    /// # Errors
+    /// If a node with the same actual path already exists in the ZooKeeper, the result will have
+    /// `Err(ZkError::NodeExists)`. Note that since a different actual path is used for each
+    /// invocation of creating sequential node with the same path argument, the call should never
+    /// error in this manner.
+    ///
+    /// If the parent node does not exist in the ZooKeeper, `Err(ZkError::NoNode)` will be returned.
+    ///
+    /// An ephemeral node cannot have children. If the parent node of the given path is ephemeral,
+    /// `Err(ZkError::NoChildrenForEphemerals)` will be returned.
+    ///
+    /// If the `acl` is invalid or empty, `Err(ZkError::InvalidACL)` is returned.
+    ///
+    /// If the `Create2` opcode is not supported by the server, `Err(ZkError::Unimplemented)` is returned.
+    ///
+    /// The maximum allowable size of the data array is 1 MiB (1,048,576 bytes). Arrays larger than
+    /// this will return `Err(ZkError::BadArguments)`.
     pub async fn create2(
         &self,
         path: &str,
@@ -323,11 +358,38 @@ impl ZooKeeper {
             acl,
             flags: mode as i32,
         };
-        let response: Create2Response = self.request(OpCode::Create2, self.xid(), req, None).await?;
+        let response: Create2Response =
+            self.request(OpCode::Create2, self.xid(), req, None).await?;
 
         Ok((self.cut_chroot(response.path), response.stat))
     }
 
+    /// Create a node with the given `path`. The node data will be the given `data`, and node ACL
+    /// will be the given `acl`. The `mode` argument specifies the behavior of the created node (see
+    /// `CreateMode` for more information).
+    /// The `ttl` argument specifies the time to live of the created node.
+    ///
+    /// This operation, if successful, will trigger all the watches left on the node of the given
+    /// path by `exists` and `get_data` API calls, and the watches left on the parent node by
+    /// `get_children` API calls.
+    ///
+    /// # Errors
+    /// If a node with the same actual path already exists in the ZooKeeper, the result will have
+    /// `Err(ZkError::NodeExists)`. Note that since a different actual path is used for each
+    /// invocation of creating sequential node with the same path argument, the call should never
+    /// error in this manner.
+    ///
+    /// If the parent node does not exist in the ZooKeeper, `Err(ZkError::NoNode)` will be returned.
+    ///
+    /// An ephemeral node cannot have children. If the parent node of the given path is ephemeral,
+    /// `Err(ZkError::NoChildrenForEphemerals)` will be returned.
+    ///
+    /// If the `acl` is invalid or empty, `Err(ZkError::InvalidACL)` is returned.
+    ///
+    /// If the `CreateTtl` opcode is not supported by the server, `Err(ZkError::Unimplemented)` is returned.
+    ///
+    /// The maximum allowable size of the data array is 1 MiB (1,048,576 bytes). Arrays larger than
+    /// this will return `Err(ZkError::BadArguments)`.
     pub async fn create2_ttl(
         &self,
         path: &str,
@@ -345,7 +407,9 @@ impl ZooKeeper {
             ttl: ttl.as_millis() as i64,
         };
 
-        let response: Create2Response = self.request(OpCode::CreateTtl, self.xid(), req, None).await?;
+        let response: Create2Response = self
+            .request(OpCode::CreateTtl, self.xid(), req, None)
+            .await?;
 
         Ok((self.cut_chroot(response.path), response.stat))
     }

--- a/src/zookeeper.rs
+++ b/src/zookeeper.rs
@@ -12,13 +12,7 @@ use tracing::*;
 
 use crate::io::ZkIo;
 use crate::listeners::ListenerSet;
-use crate::proto::{
-    to_len_prefixed_buf, AuthRequest, ByteBuf, CreateRequest, CreateResponse, DeleteRequest,
-    EmptyRequest, EmptyResponse, ExistsRequest, ExistsResponse, GetAclRequest, GetAclResponse,
-    GetChildrenRequest, GetChildrenResponse, GetDataRequest, GetDataResponse, OpCode, ReadFrom,
-    ReplyHeader, RequestHeader, SetAclRequest, SetAclResponse, SetDataRequest, SetDataResponse,
-    WriteTo,
-};
+use crate::proto::{to_len_prefixed_buf, AuthRequest, ByteBuf, CreateRequest, CreateResponse, DeleteRequest, EmptyRequest, EmptyResponse, ExistsRequest, ExistsResponse, GetAclRequest, GetAclResponse, GetChildrenRequest, GetChildrenResponse, GetDataRequest, GetDataResponse, OpCode, ReadFrom, ReplyHeader, RequestHeader, SetAclRequest, SetAclResponse, SetDataRequest, SetDataResponse, WriteTo, CreateTTLRequest, Create2Response};
 use crate::watch::ZkWatch;
 use crate::{
     Acl, CreateMode, Stat, Subscription, Watch, WatchType, WatchedEvent, Watcher, ZkError, ZkState,
@@ -267,6 +261,93 @@ impl ZooKeeper {
         let response: CreateResponse = self.request(OpCode::Create, self.xid(), req, None).await?;
 
         Ok(self.cut_chroot(response.path))
+    }
+
+    /// Create a node with the given `path`. The node data will be the given `data`, and node ACL
+    /// will be the given `acl`. The `mode` argument specifies the behavior of the created node (see
+    /// `CreateMode` for more information).
+    /// The `ttl` argument specifies the time to live of the created node.
+    ///
+    /// This operation, if successful, will trigger all the watches left on the node of the given
+    /// path by `exists` and `get_data` API calls, and the watches left on the parent node by
+    /// `get_children` API calls.
+    ///
+    /// # Errors
+    /// If a node with the same actual path already exists in the ZooKeeper, the result will have
+    /// `Err(ZkError::NodeExists)`. Note that since a different actual path is used for each
+    /// invocation of creating sequential node with the same path argument, the call should never
+    /// error in this manner.
+    ///
+    /// If the parent node does not exist in the ZooKeeper, `Err(ZkError::NoNode)` will be returned.
+    ///
+    /// An ephemeral node cannot have children. If the parent node of the given path is ephemeral,
+    /// `Err(ZkError::NoChildrenForEphemerals)` will be returned.
+    ///
+    /// If the `acl` is invalid or empty, `Err(ZkError::InvalidACL)` is returned.
+    ///
+    /// The maximum allowable size of the data array is 1 MiB (1,048,576 bytes). Arrays larger than
+    /// this will return `Err(ZkError::BadArguments)`.
+    pub async fn create_ttl(
+        &self,
+        path: &str,
+        data: Vec<u8>,
+        acl: Vec<Acl>,
+        mode: CreateMode,
+        ttl: Duration,
+    ) -> ZkResult<String> {
+        trace!("ZooKeeper::create_ttl");
+        let req = CreateTTLRequest {
+            path: self.path(path)?,
+            data,
+            acl,
+            flags: mode as i32,
+            ttl: ttl.as_millis() as i64,
+        };
+
+        let response: CreateResponse = self.request(OpCode::CreateTtl, self.xid(), req, None).await?;
+
+        Ok(self.cut_chroot(response.path))
+    }
+
+    pub async fn create2(
+        &self,
+        path: &str,
+        data: Vec<u8>,
+        acl: Vec<Acl>,
+        mode: CreateMode,
+    ) -> ZkResult<(String, Stat)> {
+        trace!("ZooKeeper::create2");
+        let req = CreateRequest {
+            path: self.path(path)?,
+            data,
+            acl,
+            flags: mode as i32,
+        };
+        let response: Create2Response = self.request(OpCode::Create2, self.xid(), req, None).await?;
+
+        Ok((self.cut_chroot(response.path), response.stat))
+    }
+
+    pub async fn create2_ttl(
+        &self,
+        path: &str,
+        data: Vec<u8>,
+        acl: Vec<Acl>,
+        mode: CreateMode,
+        ttl: Duration,
+    ) -> ZkResult<(String, Stat)> {
+        trace!("ZooKeeper::create2_ttl");
+        let req = CreateTTLRequest {
+            path: self.path(path)?,
+            data,
+            acl,
+            flags: mode as i32,
+            ttl: ttl.as_millis() as i64,
+        };
+
+        let response: Create2Response = self.request(OpCode::CreateTtl, self.xid(), req, None).await?;
+
+        Ok((self.cut_chroot(response.path), response.stat))
     }
 
     /// Delete the node with the given `path`. The call will succeed if such a node exists, and the

--- a/tests/test_ttl.rs
+++ b/tests/test_ttl.rs
@@ -1,7 +1,7 @@
+use crate::test::ZkCluster;
 use std::time::Duration;
 use tracing::info;
 use zookeeper_async::{Acl, CreateMode, WatchedEvent, Watcher, ZooKeeper};
-use crate::test::ZkCluster;
 
 mod test;
 
@@ -14,11 +14,7 @@ impl Watcher for LogWatcher {
 }
 
 async fn create_zk(connection_string: &str) -> ZooKeeper {
-    ZooKeeper::connect(
-        connection_string,
-        Duration::from_secs(10),
-        LogWatcher,
-    )
+    ZooKeeper::connect(connection_string, Duration::from_secs(10), LogWatcher)
         .await
         .unwrap()
 }
@@ -41,38 +37,155 @@ async fn zk_ttl_test() {
             Duration::from_millis(100),
         )
         .await;
-    assert_eq!(create, Ok("/test".to_owned()), "create failed: {:?}", create);
+    assert_eq!(
+        create,
+        Ok("/test".to_owned()),
+        "create failed: {:?}",
+        create
+    );
 
     // We drop connection here to make sure that the znode is deleted by the zookeeper server
     zk.close().await.unwrap();
     drop(zk);
 
-    tokio::time::sleep(Duration::from_secs(30)).await;
+    // Wait for the znode to be deleted
+    tokio::time::sleep(Duration::from_secs(60)).await;
 
     // Reconnect to the test cluster
     let zk = create_zk(&cluster.connect_string).await;
 
     let exists = zk.exists("/test", false).await;
     assert!(exists.is_ok(), "exists failed: {:?}", exists);
-    assert!(exists.unwrap().is_some(), "value should not be exist"); // << should fail here
+    assert!(exists.unwrap().is_none(), "value should not be exist");
 
-    let create2 = zk.create2(
-        "/test2",
-        vec![8, 8],
-        Acl::open_unsafe().clone(),
-        CreateMode::Persistent,
-    ).await;
 
-    println!("create2: {:?}", create2);
+    cluster.kill_an_instance();
 
-    let create2_ttl = zk.create2_ttl(
-        "/test3",
-        vec![8, 8],
-        Acl::open_unsafe().clone(),
-        CreateMode::PersistentWithTTL,
-        Duration::from_millis(100),
-    ).await;
-    println!("create2_ttl: {:?}", create2_ttl);
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_create2_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let create = zk
+        .create2(
+            "/create2_test",
+            vec![8, 8],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    match create {
+        Ok((path, _stat)) if path == "/create2_test" => {}
+        Ok((path, _stat)) => {
+            println!("create2 failed: {:?}", path);
+            assert!(false);
+        }
+        Err(e) => {
+            println!("create2 failed: {:?}", e);
+            assert!(false);
+        }
+    }
+
+    let exists = zk.exists("/create2_test", false).await;
+    assert!(exists.is_ok(), "exists failed: {:?}", exists);
+    assert!(exists.unwrap().is_some(), "value should exist");
+
+    cluster.kill_an_instance();
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_create2_sequential_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let create = zk
+        .create2(
+            "/create2_test",
+            vec![8, 8],
+            Acl::open_unsafe().clone(),
+            CreateMode::PersistentSequential,
+        )
+        .await;
+    match create {
+        Ok((path, _stat)) if path == "/create2_test0000000000" => {}
+        Ok((path, _stat)) => {
+            println!("create2 failed: {:?}", path);
+            assert!(false);
+        }
+        Err(e) => {
+            println!("create2 failed: {:?}", e);
+            assert!(false);
+        }
+    }
+
+    let exists = zk.exists("/create2_test0000000000", false).await;
+    assert!(exists.is_ok(), "exists failed: {:?}", exists);
+    assert!(exists.unwrap().is_some(), "value should exist");
+
+    cluster.kill_an_instance();
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_create2_with_ttl_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let create = zk
+        .create2_ttl(
+            "/create2_test",
+            vec![8, 8],
+            Acl::open_unsafe().clone(),
+            CreateMode::PersistentWithTTL,
+            Duration::from_millis(100),
+        )
+        .await;
+    match create {
+        Ok((path, _stat)) if path == "/create2_test" => {}
+        Ok((path, _stat)) => {
+            println!("create2 failed: {:?}", path);
+            assert!(false);
+        }
+        Err(e) => {
+            println!("create2 failed: {:?}", e);
+            assert!(false);
+        }
+    }
+
+    // We drop connection here to make sure that the znode is deleted by the zookeeper server
+    zk.close().await.unwrap();
+    drop(zk);
+
+    // Wait for the znode to be deleted
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    // Reconnect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let exists = zk.exists("/create2_test", false).await;
+    assert!(exists.is_ok(), "exists failed: {:?}", exists);
+    assert!(exists.unwrap().is_none(), "value should not be exist");
 
     cluster.kill_an_instance();
 

--- a/tests/test_ttl.rs
+++ b/tests/test_ttl.rs
@@ -1,0 +1,81 @@
+use std::time::Duration;
+use tracing::info;
+use zookeeper_async::{Acl, CreateMode, WatchedEvent, Watcher, ZooKeeper};
+use crate::test::ZkCluster;
+
+mod test;
+
+struct LogWatcher;
+
+impl Watcher for LogWatcher {
+    fn handle(&self, event: WatchedEvent) {
+        info!("{:?}", event);
+    }
+}
+
+async fn create_zk(connection_string: &str) -> ZooKeeper {
+    ZooKeeper::connect(
+        connection_string,
+        Duration::from_secs(10),
+        LogWatcher,
+    )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn zk_ttl_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let create = zk
+        .create_ttl(
+            "/test",
+            vec![8, 8],
+            Acl::open_unsafe().clone(),
+            CreateMode::PersistentWithTTL,
+            Duration::from_millis(100),
+        )
+        .await;
+    assert_eq!(create, Ok("/test".to_owned()), "create failed: {:?}", create);
+
+    // We drop connection here to make sure that the znode is deleted by the zookeeper server
+    zk.close().await.unwrap();
+    drop(zk);
+
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    // Reconnect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let exists = zk.exists("/test", false).await;
+    assert!(exists.is_ok(), "exists failed: {:?}", exists);
+    assert!(exists.unwrap().is_some(), "value should not be exist"); // << should fail here
+
+    let create2 = zk.create2(
+        "/test2",
+        vec![8, 8],
+        Acl::open_unsafe().clone(),
+        CreateMode::Persistent,
+    ).await;
+
+    println!("create2: {:?}", create2);
+
+    let create2_ttl = zk.create2_ttl(
+        "/test3",
+        vec![8, 8],
+        Acl::open_unsafe().clone(),
+        CreateMode::PersistentWithTTL,
+        Duration::from_millis(100),
+    ).await;
+    println!("create2_ttl: {:?}", create2_ttl);
+
+    cluster.kill_an_instance();
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}

--- a/zk-test-cluster/pom.xml
+++ b/zk-test-cluster/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
-            <version>5.0.0</version>
+            <version>5.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/zk-test-cluster/src/main/kotlin/zk/ZkTestCluster.kt
+++ b/zk-test-cluster/src/main/kotlin/zk/ZkTestCluster.kt
@@ -10,6 +10,8 @@ object ZkTestCluster {
 
     fun run(args: Array<String>) {
 
+        System.setProperty("zookeeper.extendedTypesEnabled", "true")
+
         if (args.isEmpty()) {
             println("Cluster size must be specified")
             exitProcess(-1)


### PR DESCRIPTION
Key enhancements include the ability to create znodes with a TTL (Time To Live) feature and the implementation of the create2 opcode. The create2 opcode allows for creating a znode while also returning its path and stat. These features enhance the library's functionality, aligning it with ZooKeeper's evolving capabilities. The pull request includes code changes, updates to dependencies, and additional unit tests to ensure the new functionalities work as expected.

Introduced new methods:
- `create_ttl`
- `create2`
- `create2_ttl`

More details about `ExtendedTypes` that enables TTL feature you can find here
https://zookeeper.apache.org/doc/r3.5.4-beta/zookeeperProgrammers.html#TTL+Nodes