### PR TITLE
Implement Transactions and Atomic Reads in Zookeeper Async Rust Client

### DIFF
--- a/examples/transactions.rs
+++ b/examples/transactions.rs
@@ -1,0 +1,106 @@
+use std::{env, time::Duration};
+
+use zookeeper_async::{WatchedEvent, Watcher, ZooKeeper};
+
+struct LoggingWatcher;
+impl Watcher for LoggingWatcher {
+    fn handle(&self, e: WatchedEvent) {
+        println!("{:?}", e)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let zk_urls = zk_server_urls();
+    println!("connecting to {}", zk_urls);
+
+    let zk = ZooKeeper::connect(&zk_urls, Duration::from_secs(15), LoggingWatcher)
+        .await
+        .unwrap();
+
+    // Create transaction that creates a node and a child node
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            zookeeper_async::Acl::open_unsafe().clone(),
+            zookeeper_async::CreateMode::Persistent,
+        )
+        .create(
+            "/test/child1",
+            vec![],
+            zookeeper_async::Acl::open_unsafe().clone(),
+            zookeeper_async::CreateMode::Persistent,
+        )
+        // Check that the node exists
+        .check("/test", None)
+        .commit()
+        .await
+        .unwrap();
+
+    for result in results {
+        println!("{:?}", result);
+    }
+
+    // Create transaction that sets data on a node
+    let results = zk
+        .transaction()
+        .create(
+            "/test2",
+            vec![],
+            zookeeper_async::Acl::open_unsafe().clone(),
+            zookeeper_async::CreateMode::Persistent,
+        )
+        .set_data("/test2", vec![1, 2, 3], None)
+        .create(
+            "/test2/child1",
+            vec![],
+            zookeeper_async::Acl::open_unsafe().clone(),
+            zookeeper_async::CreateMode::Persistent,
+        )
+        .set_data("/test2/child1", vec![4, 5, 6], None)
+        .commit()
+        .await
+        .unwrap();
+
+    for result in results {
+        println!("{:?}", result);
+    }
+
+    // Read the data from the node
+    let results = zk
+        .read()
+        .get_data("/test2", false)
+        .get_data("/test2/child1", false)
+        .execute()
+        .await
+        .unwrap();
+
+    for result in results {
+        println!("{:?}", result);
+    }
+
+    // Delete all nodes
+    let results = zk
+        .transaction()
+        .delete("/test/child1", None)
+        .delete("/test", None)
+        .delete("/test2/child1", None)
+        .delete("/test2", None)
+        .commit()
+        .await
+        .unwrap();
+
+    for result in results {
+        println!("{:?}", result);
+    }
+}
+
+fn zk_server_urls() -> String {
+    let key = "ZOOKEEPER_SERVERS";
+    match env::var(key) {
+        Ok(val) => val,
+        Err(_) => "localhost:2181".to_string(),
+    }
+}

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -7,6 +7,9 @@ use num_enum::*;
 )]
 #[repr(i32)]
 pub enum ZkError {
+    /// Operation completed successfully.
+    /// This code is used to indicate success in transaction operations.
+    Ok = 0,
     /// This code is never returned from the server. It should not be used other than to indicate a
     /// range. Specifically error codes greater than this value are API errors (while values less
     /// than this indicate a system error).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ mod consts;
 mod data;
 mod io;
 mod listeners;
+mod multi_op;
 mod paths;
 mod proto;
 pub mod recipes;
@@ -16,6 +17,7 @@ pub use self::zookeeper::{ZkResult, ZooKeeper};
 pub use acl::*;
 pub use consts::*;
 pub use data::*;
+pub use multi_op::*;
 pub use watch::{Watch, WatchType, WatchedEvent, Watcher};
 pub use zookeeper_ext::ZooKeeperExt;
 

--- a/src/multi_op.rs
+++ b/src/multi_op.rs
@@ -1,0 +1,162 @@
+use std::time::Duration;
+
+use crate::{
+    proto::{
+        CheckRequest, CreateRequest, CreateTTLRequest, DeleteRequest, GetDataRequest, Op,
+        SetDataRequest,
+    },
+    Acl, CreateMode, Stat, ZkResult, ZooKeeper,
+};
+
+#[derive(Debug)]
+pub enum OperationResult {
+    Create(String),
+    Create2(String, Stat),
+    CreateTtl(String, Stat),
+    SetData(Stat),
+    Delete,
+    Check,
+}
+
+#[derive(Debug)]
+pub enum ReadOperationResult {
+    GetData(Vec<u8>, Stat),
+    GetChildren(Vec<String>),
+}
+
+pub struct Transaction<'a> {
+    zookeeper: &'a ZooKeeper,
+    operations: Vec<Op>,
+}
+
+pub struct Read<'a> {
+    zookeeper: &'a ZooKeeper,
+    operations: Vec<Op>,
+}
+
+impl<'a> Transaction<'a> {
+    pub fn new(zookeeper: &'a ZooKeeper) -> Self {
+        Self {
+            zookeeper,
+            operations: Vec::new(),
+        }
+    }
+
+    /// See [ZooKeeper::create]
+    pub fn create(mut self, path: &str, data: Vec<u8>, acl: Vec<Acl>, mode: CreateMode) -> Self {
+        self.operations.push(Op::Create(CreateRequest {
+            path: path.to_string(),
+            data,
+            acl,
+            flags: mode as i32,
+        }));
+        self
+    }
+
+    /// See [ZooKeeper::create2]
+    pub fn create2(mut self, path: &str, data: Vec<u8>, acl: Vec<Acl>, mode: CreateMode) -> Self {
+        self.operations.push(Op::Create2(CreateRequest {
+            path: path.to_string(),
+            data,
+            acl,
+            flags: mode as i32,
+        }));
+        self
+    }
+
+    /// See [ZooKeeper::create_ttl]
+    pub fn create_ttl(
+        mut self,
+        path: &str,
+        data: Vec<u8>,
+        acl: Vec<Acl>,
+        mode: CreateMode,
+        ttl: Duration,
+    ) -> Self {
+        self.operations.push(Op::CreateTtl(CreateTTLRequest {
+            path: path.to_string(),
+            data,
+            acl,
+            flags: mode as i32,
+            ttl: ttl.as_millis() as i64,
+        }));
+        self
+    }
+
+    /// See [ZooKeeper::set_data]
+    pub fn set_data(mut self, path: &str, data: Vec<u8>, version: Option<i32>) -> Self {
+        self.operations.push(Op::SetData(SetDataRequest {
+            path: path.to_string(),
+            data,
+            version: version.unwrap_or(-1),
+        }));
+        self
+    }
+
+    /// See [ZooKeeper::delete]
+    pub fn delete(mut self, path: &str, version: Option<i32>) -> Self {
+        self.operations.push(Op::Delete(DeleteRequest {
+            path: path.to_string(),
+            version: version.unwrap_or(-1),
+        }));
+        self
+    }
+
+    /// Check if the path exists and the version matches. If the version is not provided, it will
+    /// check if the path exists.
+    pub fn check(mut self, path: &str, version: Option<i32>) -> Self {
+        self.operations.push(Op::Check(CheckRequest {
+            path: path.to_string(),
+            version: version.unwrap_or(-1),
+        }));
+        self
+    }
+
+    /// Commit the transaction
+    ///
+    /// # Errors
+    ///
+    /// If any of the operations fail, the first error will be returned.
+    ///
+    /// See [ZooKeeper] for more information on errors.
+    /// See [crate::ZkError] for list of possible errrors.
+    pub async fn commit(self) -> ZkResult<Vec<OperationResult>> {
+        self.zookeeper.multi(self.operations).await
+    }
+}
+
+impl<'a> Read<'a> {
+    pub fn new(zookeeper: &'a ZooKeeper) -> Self {
+        Self {
+            zookeeper,
+            operations: Vec::new(),
+        }
+    }
+    /// See [ZooKeeper::get_data]
+    pub fn get_data(mut self, path: &str, watch: bool) -> Self {
+        self.operations.push(Op::GetData(GetDataRequest {
+            path: path.to_string(),
+            watch,
+        }));
+        self
+    }
+
+    /// See [ZooKeeper::get_children]
+    pub fn get_children(mut self, path: &str, watch: bool) -> Self {
+        self.operations.push(Op::GetChildren(GetDataRequest {
+            path: path.to_string(),
+            watch,
+        }));
+        self
+    }
+
+    /// # Errors
+    ///
+    /// If any of the operations fail, the first error will be returned.
+    ///
+    /// See [ZooKeeper] for more information on errors.
+    /// See [crate::ZkError] for list of possible errrors.
+    pub async fn execute(self) -> ZkResult<Vec<ReadOperationResult>> {
+        self.zookeeper.multi_read(self.operations).await
+    }
+}

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -21,6 +21,8 @@ pub enum OpCode {
 
     Create2 = 15,
     CreateTtl = 21,
+
+    GetAllChildrenNumber = 104,
 }
 
 pub type ByteBuf = Cursor<Vec<u8>>;
@@ -430,6 +432,28 @@ impl ReadFrom for GetChildrenResponse {
             children.push(reader.read_string()?);
         }
         Ok(GetChildrenResponse { children })
+    }
+}
+
+pub struct GetAllChildrenNumberRequest {
+    pub path: String,
+}
+
+impl WriteTo for GetAllChildrenNumberRequest {
+    fn write_to(&self, writer: &mut dyn Write) -> Result<()> {
+        self.path.write_to(writer)
+    }
+}
+
+pub struct GetAllChildrenNumberResponse {
+    pub total_number: i32,
+}
+
+impl ReadFrom for GetAllChildrenNumberResponse {
+    fn read_from<R: Read>(reader: &mut R) -> Result<GetAllChildrenNumberResponse> {
+        Ok(GetAllChildrenNumberResponse {
+            total_number: reader.read_i32::<BigEndian>()?,
+        })
     }
 }
 

--- a/tests/test_get_all_children_number.rs
+++ b/tests/test_get_all_children_number.rs
@@ -1,0 +1,160 @@
+use crate::test::ZkCluster;
+use std::time::Duration;
+use tracing::info;
+use zookeeper_async::{Acl, CreateMode, WatchedEvent, Watcher, ZooKeeper};
+
+mod test;
+
+struct LogWatcher;
+
+impl Watcher for LogWatcher {
+    fn handle(&self, event: WatchedEvent) {
+        info!("{:?}", event);
+    }
+}
+
+async fn create_zk(connection_string: &str) -> ZooKeeper {
+    ZooKeeper::connect(connection_string, Duration::from_secs(10), LogWatcher)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn zk_get_all_children_number_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let _ = zk
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    // create few children of /test
+    let _ = zk
+        .create(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child2",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child3",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+
+    let children = zk.get_all_children_number("/test").await;
+
+    assert_eq!(
+        children,
+        Ok(3),
+        "get_all_children_number failed: {:?}",
+        children
+    );
+
+    cluster.kill_an_instance();
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_get_all_children_number_with_subtree_test() {
+    // Create a test cluster
+    let mut cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    // Do the tests
+    let _ = zk
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    // create few children of /test
+    let _ = zk
+        .create(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child2",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child2/child21",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child3",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child3/child31",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+    let _ = zk
+        .create(
+            "/test/child3/child31/child311",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .await;
+
+    let children = zk.get_all_children_number("/test").await;
+
+    assert_eq!(
+        children,
+        Ok(6),
+        "get_all_children_number failed: {:?}",
+        children
+    );
+
+    cluster.kill_an_instance();
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}

--- a/tests/test_multi.rs
+++ b/tests/test_multi.rs
@@ -1,0 +1,268 @@
+use crate::test::ZkCluster;
+use std::time::Duration;
+use zookeeper_async::{Acl, CreateMode, ZkError, ZooKeeper};
+
+mod test;
+
+async fn create_zk(connection_string: &str) -> ZooKeeper {
+    ZooKeeper::connect(connection_string, Duration::from_secs(10), |_ev| {})
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn zk_multi() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .create(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .check("/test", Some(0))
+        .commit()
+        .await;
+
+    assert!(results.is_ok());
+    let results = results.unwrap();
+    assert_eq!(results.len(), 3);
+
+    assert!(zk.exists("/test", false).await.unwrap().is_some());
+    assert!(zk.exists("/test/child1", false).await.unwrap().is_some());
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_multi_w_set_data() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk
+        .transaction()
+        .create2(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .create2(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .set_data("/test", vec![1, 2, 3], None)
+        .check("/test", Some(1))
+        .commit()
+        .await;
+
+    assert!(results.is_ok());
+    let results = results.unwrap();
+    assert_eq!(results.len(), 4);
+
+    assert!(zk.exists("/test", false).await.unwrap().is_some());
+    assert!(zk.exists("/test/child1", false).await.unwrap().is_some());
+
+    let data = zk.get_data("/test", false).await.unwrap();
+    assert_eq!(data.0, vec![1, 2, 3]);
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_multi_w_delete() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .create(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .delete("/test/child1", None)
+        .commit()
+        .await;
+
+    assert!(results.is_ok());
+    let results = results.unwrap();
+    assert_eq!(results.len(), 3);
+
+    assert!(zk.exists("/test", false).await.unwrap().is_some());
+    assert!(zk.exists("/test/child1", false).await.unwrap().is_none());
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_multi_error() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .check("/test", Some(2)) // This should fail because the version is wrong
+        .commit()
+        .await;
+
+    let Err(error) = results else {
+        panic!("Expected an error");
+    };
+
+    assert_eq!(error, ZkError::BadVersion);
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .check("/test-wrong", None)
+        .commit()
+        .await;
+
+    let Err(error) = results else {
+        panic!("Expected an error");
+    };
+
+    assert_eq!(error, ZkError::NoNode);
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .commit()
+        .await;
+
+    let Err(error) = results else {
+        panic!("Expected an error");
+    };
+
+    assert_eq!(error, ZkError::NodeExists);
+
+    // Ensure that the transaction was not committed
+
+    assert!(zk.exists("/test", false).await.unwrap().is_none());
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_multi_read() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk
+        .transaction()
+        .create(
+            "/test",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .create(
+            "/test/child1",
+            vec![],
+            Acl::open_unsafe().clone(),
+            CreateMode::Persistent,
+        )
+        .commit()
+        .await;
+
+    assert!(results.is_ok());
+    let results = results.unwrap();
+    assert_eq!(results.len(), 2);
+
+    let results = zk
+        .read()
+        .get_data("/test", false)
+        .get_children("/test", false)
+        .execute()
+        .await;
+
+    // assert!(results.is_ok());
+    let results = results.unwrap();
+    assert_eq!(results.len(), 2);
+
+    assert!(zk.exists("/test", false).await.unwrap().is_some());
+    assert!(zk.exists("/test/child1", false).await.unwrap().is_some());
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn zk_multi_read_error() {
+    // Create a test cluster
+    let cluster = ZkCluster::start(3);
+
+    // Connect to the test cluster
+    let zk = create_zk(&cluster.connect_string).await;
+
+    let results = zk.read().get_data("/test", false).execute().await;
+
+    let Err(error) = results else {
+        panic!("Expected an error");
+    };
+
+    assert_eq!(error, ZkError::NoNode);
+
+    // After closing the client all operations return Err
+    zk.close().await.unwrap();
+}


### PR DESCRIPTION
This PR introduces the implementation of transactions and atomic reads. The primary objective is to enable multiple operations to execute atomically, ensuring data consistency and integrity. Additionally, atomic reads have been added to allow for efficient and consistent read operations.

**Changes:**

1. Transaction Support:
  - Implemented the Transaction builder to facilitate the creation of transactional operations.
  - Added support for the following transactional operations:
    - Create
    - Create2
    - CreateTtl
    - SetData
    - Delete
    - Check (checking the existence and version of a znode)
2. Atomic Reads:
    - Implemented the Read builder to enable atomic read operations.
    - Added support for the following read operations:
      - GetData
      - GetChildren
3. ZooKeeper Client Enhancements:
    - Added functions to the ZooKeeper struct for easily creating the `Transaction` and `Read` builders:
    ```rust
      pub fn transaction(&self) -> Transaction;
      pub fn read(&self) -> Read;
    ```
4. Additional Changes:
    - Introduced a new function to the ZooKeeper client:
    ```rust
      pub async fn get_all_children_number(&self, path: &str) -> ZkResult<i32>
    ```
    - This function returns the number of children of the node at the given path.
    - This operation returns the number of children recursively. It means the following znode tree has **6** children by path `/test`
    ```
        /test
        /test/child1
        /test/child2/child21
        /test/child3/child31/child311
    ```

**Testing:**

- Added unit tests to verify the functionality of transactional operations.
- Added unit tests for atomic read operations.
- Included test cases for the get_all_children_number function.
- Ensured all existing tests pass without issues.